### PR TITLE
Add: タイトルを動的に表示

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,7 @@
 module ApplicationHelper
+  def page_title(page_title = '')
+    base_title = t'defaults.site_title'
+
+    page_title.empty? ? base_title : page_title + ' | ' + base_title
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>OKaitoku</title>
+    <title><%= page_title(yield(:title)) %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title) %>
 <div class="top-wrapper">
   <div class="top-inner-text">
     <h1>Static Pages</h1>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t('.title')) %>
 <div class="container">
   <div class="row">
     <div class=" col-md-10 offset-md-1 col-lg-8 offset-lg-2">

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t('.title')) %>
 <div class="container">
   <div class="row">
     <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -3,6 +3,7 @@ ja:
     login: 'ログイン'
     signup: '登録'
     logout: 'ログアウト'
+    site_title: 'Viva Price'
     message:
       not_authenticated: 'ログインしてください'
       created: '%{item}を作成しました'


### PR DESCRIPTION
### 内容
- `application_helper.rb`にビューファイルのタイトルが動的に表示されるようメソッドを追加しました。

### 確認
- 既存のページにアクセスしてタイトルが動的に表示されていることを確認
<img width="258" alt="909631b7650f91202dc624ee7b6f0fe1" src="https://user-images.githubusercontent.com/101347928/212232633-a59ae953-abb7-4eac-bdfb-fc37d5a31929.png">
<img width="247" alt="e476faa8c9d9333be46bdf1dd1226d46" src="https://user-images.githubusercontent.com/101347928/212232647-6d31bea0-aa73-4cbe-9ae1-9830c1709cf7.png">

### Issues
close #19 